### PR TITLE
Changing the pagination UI and adjusting the tagging system

### DIFF
--- a/context/state.js
+++ b/context/state.js
@@ -7,7 +7,10 @@ export const TaxonomySlugProvider = ({ children }) => {
     ...new Set(
       posts.reduce((acc, post) => [...acc, ...post.frontmatter.categories], [])
     ),
-  ].map((item) => ({ name: item, url: `/categories/${item.toLowerCase()}` }));
+  ].map((item) => ({
+    name: item.replace(/-/g, " "), 
+    url: `/categories/${item.toLowerCase().replace(/\s+/g, '-')}`,
+  }));
   return (
     <HeaderContext.Provider value={{ categories }}>
       {children}

--- a/layouts/components/Pagination.js
+++ b/layouts/components/Pagination.js
@@ -15,14 +15,13 @@ const Pagination = ({ currentPage, totalPages }) => {
     <>
       {totalPages > 1 && (
         <nav
-          className="mb-4 flex justify-center -space-x-px"
+          className="mb-4 flex flex-wrap justify-center -space-x-px"
           aria-label="Pagination"
         >
-          {/* previous */}
           {hasPrevPage ? (
             <Link
               href={indexPageLink ? "/" : `/page/${currentPage - 1}`}
-              className="border border-primary px-2 py-2 text-text"
+              className="border border-primary px-2 py-2 text-text sm:px-3 sm:py-2 text-sm flex-basis-1/2"
             >
               <>
                 <span className="sr-only">Previous</span>
@@ -42,7 +41,7 @@ const Pagination = ({ currentPage, totalPages }) => {
               </>
             </Link>
           ) : (
-            <span className="border border-primary px-2 py-2 text-text">
+            <span className="border border-primary px-2 py-2 text-text sm:px-3 sm:py-2 text-sm flex-basis-1/2">
               <>
                 <span className="sr-only">Previous</span>
                 <svg
@@ -62,13 +61,12 @@ const Pagination = ({ currentPage, totalPages }) => {
             </span>
           )}
 
-          {/* page index */}
           {pageList.map((pagination, i) => (
             <React.Fragment key={`page-${i}`}>
               {pagination === currentPage ? (
                 <span
                   aria-current="page"
-                  className={`border border-primary bg-primary px-4 py-2 text-white`}
+                  className={`border border-primary bg-primary px-4 py-2 text-white sm:px-3 sm:py-2 text-sm flex-basis-1/2`}
                 >
                   {pagination}
                 </span>
@@ -77,7 +75,7 @@ const Pagination = ({ currentPage, totalPages }) => {
                   href={i === 0 ? `${"/"}` : `/page/${pagination}`}
                   passHref
                   aria-current="page"
-                  className={`border border-primary px-4 py-2 text-text`}
+                  className={`border border-primary px-4 py-2 text-text sm:px-3 sm:py-2 text-sm flex-basis-1/2`}
                 >
                   {pagination}
                 </Link>
@@ -85,11 +83,10 @@ const Pagination = ({ currentPage, totalPages }) => {
             </React.Fragment>
           ))}
 
-          {/* next page */}
           {hasNextPage ? (
             <Link
               href={`/page/${currentPage + 1}`}
-              className="border border-primary px-2 py-2 text-text"
+              className="border border-primary px-2 py-2 text-text sm:px-3 sm:py-2 text-sm flex-basis-1/2"
             >
               <>
                 <span className="sr-only">Next</span>
@@ -109,7 +106,7 @@ const Pagination = ({ currentPage, totalPages }) => {
               </>
             </Link>
           ) : (
-            <span className="border border-primary px-2 py-2 text-text">
+            <span className="border border-primary px-2 py-2 text-text sm:px-3 sm:py-2 text-sm flex-basis-1/2">
               <>
                 <span className="sr-only">Next</span>
                 <svg

--- a/pages/[regular].js
+++ b/pages/[regular].js
@@ -12,7 +12,7 @@ const RegularPages = ({ data }) => {
 
   return (
     <Base
-      title={title}
+      title={`${title.replace(/-/g, " ")}`}
       description={description ? description : content.slice(0, 120)}
       meta_title={meta_title}
       image={image}

--- a/pages/categories/[category].js
+++ b/pages/categories/[category].js
@@ -15,7 +15,7 @@ const Category = ({ posts, slug }) => {
         <div className="container">
           <div className="row">
             <div className="mx-auto lg:col-10">
-              <h1 className="text-center capitalize">{slug}</h1>
+              <h1 className="text-center capitalize">{slug.replace(/-/g, " ")}</h1>
               <div className="row pt-12">
                 {posts.map((post, i) => (
                   <Post


### PR DESCRIPTION
Hello! 

I created a site with translations of stories in Russian based on your starter whale. You can find it at the link - malifaux.ru

When filling the starter with content I encountered two problems:

1. If the tag consists of two words, the search would break.

2. If there were very many pages in the pagination, on mobile devices, the edges of the pagination went beyond the boundaries of the screen.

I solved these uncomplicated problems. Although, of course, my solution to the pagination problem looks messy and I plan to rewrite it completely in the future. 